### PR TITLE
Update makefile to use gcc-3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
   - sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
   - gcc --version
   - gcc-3.3 --version
+  - ls /
+  - find /lib/ -name libgcc*
   - find /usr/ -name libgcc*
   - sudo /sbin/ldconfig -p | grep libgcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ before_install:
   - travis_retry sudo add-apt-repository -y "deb http://snapshot.debian.org/archive/debian/20070730T000000Z/ lenny main"
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get -y --force-yes install gcc-3.3
+  - sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
   - gcc --version
+  - gcc-3.3 --version
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
   - sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
   - gcc --version
   - gcc-3.3 --version
+  - find /usr/ -name libgcc*
+  - sudo /sbin/ldconfig -p | grep libgcc
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 before_install:
   - sudo add-apt-repository -y "deb http://snapshot.debian.org/archive/debian/20070730T000000Z/ lenny main"
   - sudo apt-get update
-  - sudo apt-get -y --force-yes install gcc-3.3 libgcc
+  - sudo apt-get -y --force-yes install gcc-3.3 libgcc1
   - sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
   - gcc --version
   - gcc-3.3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: c
 
 before_install:
-  - travis_retry sudo add-apt-repository -y "deb http://snapshot.debian.org/archive/debian/20070730T000000Z/ lenny main"
-  - travis_retry sudo apt-get update
-  - travis_retry sudo apt-get -y --force-yes install gcc-3.3
+  - sudo add-apt-repository -y "deb http://snapshot.debian.org/archive/debian/20070730T000000Z/ lenny main"
+  - sudo apt-get update
+  - sudo apt-get -y --force-yes install gcc-3.3 libgcc
   - sudo ln -s /usr/lib/x86_64-linux-gnu /usr/lib64
   - gcc --version
   - gcc-3.3 --version

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	gcc monitor_test_prop_1.c copilot-c99-codegen-prop_1/copilot.c triggers_prop_1.c -o prop1
-	gcc monitor_test_prop_2.c copilot-c99-codegen-prop_2/copilot.c triggers_prop_2.c -o prop2
-	gcc monitor_test_prop_3.c copilot-c99-codegen-prop_1/copilot.c triggers_prop_3.c -o prop3
-	gcc monitor_test_prop_4.c copilot-c99-codegen-prop_2/copilot.c triggers_prop_4.c -o prop4
+	gcc-3.3 monitor_test_prop_1.c copilot-c99-codegen-prop_1/copilot.c triggers_prop_1.c -o prop1
+	gcc-3.3 monitor_test_prop_2.c copilot-c99-codegen-prop_2/copilot.c triggers_prop_2.c -o prop2
+	gcc-3.3 monitor_test_prop_3.c copilot-c99-codegen-prop_1/copilot.c triggers_prop_3.c -o prop3
+	gcc-3.3 monitor_test_prop_4.c copilot-c99-codegen-prop_2/copilot.c triggers_prop_4.c -o prop4


### PR DESCRIPTION
If you look at the travis build, gcc is linked to gcc-4.6 or some such. This pull request should maybe trigger a build with the 3.3 version.
